### PR TITLE
Update OpenQASM link in qiskit-sim README

### DIFF
--- a/packages/qiskit-sim/README.md
+++ b/packages/qiskit-sim/README.md
@@ -1,6 +1,6 @@
 # Qiskit.js simulator
 
-:atom_symbol: [Quantum Information Science Kit](https://developer.ibm.com/open/openprojects/qiskit) simulator in pure JavaScript. As a first feature it includes an unitary one, with specific support for [OpenQASM](https://github.com/IBM/qisim.js-openqasm) circuits representation.
+:atom_symbol: [Quantum Information Science Kit](https://developer.ibm.com/open/openprojects/qiskit) simulator in pure JavaScript. As a first feature it includes an unitary one, with specific support for [OpenQASM](https://github.com/Qiskit/openqasm) circuits representation.
 
 Please visit the [main repository](https://github.com/Qiskit/qiskit-js) to know more about the rest of the project tools.
 


### PR DESCRIPTION
### Summary
Currently this link results in a 404. This commit updates it to point to
Qiskit/openqasm which was my best guess for this link.

