### PR TITLE
Introduce Gate class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### 🎉 Added
+
+- `@qiskit/qiskit-sim`: Introduce Gate class
+
 ## [0.6.2] - 2019-03-13
 
 ### ✏️ Changed

--- a/packages/qiskit-sim/README.md
+++ b/packages/qiskit-sim/README.md
@@ -36,8 +36,8 @@ function randomizeInput(nQubits) {
 
 const circuit = new sim.Circuit({ nQubits: 2 });
 
-circuit.addGate('h', 0, 0);
-circuit.addGate('cx', 1, [0, 1]);
+circuit.addGate(sim.Gate.h, 0, 0);
+circuit.addGate(sim.Gate.cx, 1, [0, 1]);
 
 console.log('\nInput randomized (as string):');
 const input = randomizeInput(circuit.nQubits);

--- a/packages/qiskit-sim/index.js
+++ b/packages/qiskit-sim/index.js
@@ -10,11 +10,12 @@
 'use strict';
 
 const { version } = require('./package');
-const gates = require('./lib/gates');
+const { Gate, gates } = require('./lib/gates');
 const Circuit = require('./lib/Circuit');
 
 module.exports = {
   version,
   gates,
+  Gate,
   Circuit,
 };

--- a/packages/qiskit-sim/lib/gates.js
+++ b/packages/qiskit-sim/lib/gates.js
@@ -25,7 +25,8 @@ const identityMatrix = n => {
   return matrix;
 };
 
-const buildControlled = U => {
+const buildControlled = Gate => {
+  const U = Gate.matrix;
   const m = U.length;
   const C = identityMatrix(m * 2);
 
@@ -38,49 +39,66 @@ const buildControlled = U => {
   return C;
 };
 
-const gates = {
-  x: [[0, 1], [1, 0]],
-  y: [[0, math.multiply(-1, math.i)], [math.i, 0]],
-  z: [[1, 0], [0, -1]],
-  h: [
-    [1 / math.sqrt(2), 1 / math.sqrt(2)],
-    [1 / math.sqrt(2), 0 - 1 / math.sqrt(2)],
-  ],
-  srn: [
-    [1 / math.sqrt(2), 0 - 1 / math.sqrt(2)],
-    [1 / math.sqrt(2), 1 / math.sqrt(2)],
-  ],
-  s: [[1, 0], [0, math.pow(math.e, math.multiply(math.i, math.PI / 2))]],
-  r2: [[1, 0], [0, math.pow(math.e, math.multiply(math.i, math.PI / 2))]],
-  r4: [[1, 0], [0, math.pow(math.e, math.multiply(math.i, math.PI / 4))]],
-  r8: [[1, 0], [0, math.pow(math.e, math.multiply(math.i, math.PI / 8))]],
-  swap: [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]],
-  srswap: [
-    [1, 0, 0, 0],
-    [
-      0,
-      math.multiply(0.5, math.add(1, math.i)),
-      math.multiply(0.5, math.subtract(1, math.i)),
-      0,
-    ],
-    [
-      0,
-      math.multiply(0.5, math.subtract(1, math.i)),
-      math.multiply(0.5, math.add(1, math.i)),
-      0,
-    ],
-    [0, 0, 0, 1],
-  ],
+class Gate {
+  constructor(name, matrix) {
+    this.name = name;
+    this.matrix = matrix;
+  }
+}
+
+Gate.x = new Gate('x', [[0, 1], [1, 0]]);
+Gate.y = new Gate('y', [[0, math.multiply(-1, math.i)], [math.i, 0]]);
+Gate.z = new Gate('z', [[1, 0], [0, -1]]);
+Gate.h = new Gate('h',
+                  [[1 / math.sqrt(2), 1 / math.sqrt(2)],
+                   [1 / math.sqrt(2), 0 - 1 / math.sqrt(2)]]);
+Gate.srn = new Gate('srn',
+                    [[1 / math.sqrt(2), 0 - 1 / math.sqrt(2)],
+                     [1 / math.sqrt(2), 1 / math.sqrt(2)]]);
+Gate.s = new Gate('s',
+                  [[1, 0],
+                   [0, math.pow(math.e, math.multiply(math.i, math.PI / 2))]]);
+Gate.r2 = new Gate('r2',
+                   [[1, 0],
+                    [0, math.pow(math.e, math.multiply(math.i, math.PI / 2))]]);
+Gate.r4 = new Gate('r4',
+                   [[1, 0],
+                    [0, math.pow(math.e, math.multiply(math.i, math.PI / 4))]]);
+Gate.r8 = new Gate('r8',
+                   [[1, 0],
+                    [0, math.pow(math.e, math.multiply(math.i, math.PI / 8))]]);
+Gate.swap = new Gate('swap',
+                     [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]);
+Gate.srswap = new Gate('srswap',
+                      [
+                        [1, 0, 0, 0],
+                        [
+                          0,
+                          math.multiply(0.5, math.add(1, math.i)),
+                          math.multiply(0.5, math.subtract(1, math.i)),
+                          0,
+                        ],
+                        [
+                          0,
+                          math.multiply(0.5, math.subtract(1, math.i)),
+                          math.multiply(0.5, math.add(1, math.i)),
+                          0,
+                        ],
+                        [0, 0, 0, 1],
+                      ]);
+Gate.cx = new Gate('cx', buildControlled(Gate.x));
+Gate.cy = new Gate('cy', buildControlled(Gate.y));
+Gate.cz = new Gate('cz', buildControlled(Gate.z));
+Gate.ch = new Gate('ch', buildControlled(Gate.h));
+Gate.csrn = new Gate('csrn', buildControlled(Gate.srn));
+Gate.cs = new Gate('cs', buildControlled(Gate.s));
+Gate.cr2 = new Gate('cr2', buildControlled(Gate.r2));
+Gate.cr4 = new Gate('cr4', buildControlled(Gate.r4));
+Gate.cr8 = new Gate('cr8', buildControlled(Gate.r8));
+
+const gates = new Map(Object.entries(Gate));
+
+module.exports = {
+  Gate,
+  gates
 };
-
-gates.cx = buildControlled(gates.x);
-gates.cy = buildControlled(gates.y);
-gates.cz = buildControlled(gates.z);
-gates.ch = buildControlled(gates.h);
-gates.csrn = buildControlled(gates.srn);
-gates.cs = buildControlled(gates.s);
-gates.cr2 = buildControlled(gates.r2);
-gates.cr4 = buildControlled(gates.r4);
-gates.cr8 = buildControlled(gates.r8);
-
-module.exports = gates;

--- a/packages/qiskit-sim/test/functional/Circuit.js
+++ b/packages/qiskit-sim/test/functional/Circuit.js
@@ -11,14 +11,14 @@
 
 const assert = require('assert');
 
-const { Circuit } = require('../..');
+const { Circuit, Gate } = require('../..');
 
 const circuit = new Circuit();
 const circuitMulti = new Circuit({ nQubits: 2 });
 
-circuit.addGate('h', 0, 0);
-circuitMulti.addGate('h', 0, 0);
-circuitMulti.addGate('cx', 1, [0, 1]);
+circuit.addGate(Gate.h, 0, 0);
+circuitMulti.addGate(Gate.h, 0, 0);
+circuitMulti.addGate(Gate.cx, 1, [0, 1]);
 
 function checkValid(circ) {
   assert.equal(circ.nQubits, 1);
@@ -38,7 +38,7 @@ describe('sim:Circuit:addGate', () => {
     const circuitOther = new Circuit();
 
     circuitOther.addGate('h', 0, 0);
-    circuitOther.addGate('cx', 1, [0, 1]);
+    circuitOther.addGate(Gate.cx, 1, [0, 1]);
 
     assert.equal(circuitOther.nQubits, 2);
   });

--- a/packages/qiskit-sim/test/functional/gates.js
+++ b/packages/qiskit-sim/test/functional/gates.js
@@ -15,7 +15,7 @@ const { gates } = require('../..');
 
 describe('sim:gates', () => {
   it('should include all supported ones', () =>
-    assert.deepEqual(Object.keys(gates), [
+    assert.deepEqual([...gates.keys()], [
       'x',
       'y',
       'z',

--- a/packages/qiskit-sim/test/functional/index.js
+++ b/packages/qiskit-sim/test/functional/index.js
@@ -16,7 +16,7 @@ const pkgInfo = require('../../package');
 
 describe('sim:index', () => {
   it('should include all documented root elements', () => {
-    assert.deepEqual(Object.keys(sim), ['version', 'gates', 'Circuit']);
+    assert.deepEqual(Object.keys(sim), ['version', 'gates', 'Gate', 'Circuit']);
   });
 });
 


### PR DESCRIPTION
### Summary
This commit introduces a Gate class to enable passing in instances of
these types when adding gates to a circuit as an alternative to passing
in the name of the gate as a string. 

### Details and comments
Having the ability to take a Gate allows for some useful tab completion for new users like myself. The example below show how adding a gate to a circuit can be done:
```console
$ node
> const q = require('./index.js')
> const circuit = new q.Circuit(1)
> circuit.addGate(q.Gate.
q.Gate.__defineGetter__      q.Gate.__defineSetter__      q.Gate.__lookupGetter__      q.Gate.__lookupSetter__      q.Gate.__proto__
q.Gate.hasOwnProperty        q.Gate.isPrototypeOf         q.Gate.propertyIsEnumerable  q.Gate.toLocaleString        q.Gate.valueOf

q.Gate.apply                 q.Gate.arguments             q.Gate.bind                  q.Gate.call                  q.Gate.caller
q.Gate.constructor           q.Gate.toString

q.Gate.ch                    q.Gate.cr2                   q.Gate.cr4                   q.Gate.cr8                   q.Gate.cs
q.Gate.csrn                  q.Gate.cx                    q.Gate.cy                    q.Gate.cz                    q.Gate.h
q.Gate.length                q.Gate.name                  q.Gate.prototype             q.Gate.r2                    q.Gate.r4
q.Gate.r8                    q.Gate.s                     q.Gate.srn                   q.Gate.srswap                q.Gate.swap
q.Gate.x                     q.Gate.y                     q.Gate.z
> circuit.addGate(q.Gate.x, 0, 0)
```


