### PR TITLE
Update packages links in qiskit-devs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### ✏️ Changed
 
 - Update Node.js install instruction in README.md
+- Update packages links in qiskit-devs
 
 ## [0.6.2] - 2019-03-13
 

--- a/packages/qiskit-devs/README.md
+++ b/packages/qiskit-devs/README.md
@@ -32,7 +32,7 @@ qiskit
 
 ## API
 
-:eyes: Full specification. Here are reflected the common options among the different engines, but some of them can receive (even need) extra ones, ie: an API key. Please check the [proper package](packages).
+:eyes: Full specification. Here are reflected the common options among the different engines, but some of them can receive (even need) extra ones, ie: an API key. Please check the [packages].
 
 ### `version`
 
@@ -45,7 +45,7 @@ The actual version of the library.
 Generate a true random number among 0 and 1.
 
 - `opts` (object) - Optional parameters:
-  - `engine` (string) - Where to run the operation. Please visit the [packages](https://github.ibm.com/jesusper/qiskit-js-next/tree/master/packages) to see the supported ones. The number of digits depends on the selected engine. (default: "js")
+  - `engine` (string) - Where to run the operation. Please visit the [packages] to see the supported ones. The number of digits depends on the selected engine. (default: "js")
   - `length` (number) - Number of random hex characters to ask for to the engine. As you can see in the doc referenced before each engine has different limit, they will throw in it's overpassed. (default: 16)
   - `format` (string) - To ask for the result in a different format, supported ("hex").
   - `custom` (string/object) - Custom stuff (API key, inited connector instance, etc) needed for some backends (visit each specific doc).
@@ -70,3 +70,5 @@ Integer factorization in prime numbers using [Shor's algorithm](https://en.wikip
 
 - `number` (number/string) - Number to factorize, an integer for now.
 - `prime` (number) - Prime factor of the passed one.
+
+[packages]: ./..


### PR DESCRIPTION
### Summary
Currently there is one link named `proper packages` that does not have a
values specified for it. There is also another link named `packages` which
points (I'm guessing here) to an IBM internal repository.


### Details and comments
This commit suggests updating both links to point to the packages
directory. My reasoning here is that these should point to the currently
supported packages, `qiskit-devs-anu`, `qiskit-devs-ibm`, and
`qiskit-devs-js`. 


