### PR TITLE
Add the identity (id) gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### 🎉 Added
 
 - `@qiskit/qiskit-sim`: Introduce Gate class
+- `@qiskit/qiskit-sim`: Add the identity (id) gate
 
 ### ✏️ Changed
 

--- a/packages/qiskit-sim/lib/gates.js
+++ b/packages/qiskit-sim/lib/gates.js
@@ -49,6 +49,7 @@ class Gate {
 Gate.x = new Gate('x', [[0, 1], [1, 0]]);
 Gate.y = new Gate('y', [[0, math.multiply(-1, math.i)], [math.i, 0]]);
 Gate.z = new Gate('z', [[1, 0], [0, -1]]);
+Gate.id = new Gate('id', [[1, 0], [0, 1]]);
 Gate.h = new Gate('h',
                   [[1 / math.sqrt(2), 1 / math.sqrt(2)],
                    [1 / math.sqrt(2), 0 - 1 / math.sqrt(2)]]);

--- a/packages/qiskit-sim/test/functional/gates.js
+++ b/packages/qiskit-sim/test/functional/gates.js
@@ -19,6 +19,7 @@ describe('sim:gates', () => {
       'x',
       'y',
       'z',
+      'id',
       'h',
       'srn',
       's',


### PR DESCRIPTION
### Summary
This commit adds the identity gate.


### Details and comments
The motivation for this is that this gate is available in QASM [qelib1.inc](https://github.com/Qiskit/qiskit-js/blob/d7121dedef743cc365a0b8dce2daf732562bc7cc/packages/qiskit-qasm/core/qelib1.inc#L15) but does not exist in the gates currently provided by qiskit-sim.
