### PR TITLE
Support method chaining for addGate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update Node.js install instruction in README.md
 - Update packages links in qiskit-devs
+- `@qiskit/qiskit-sim`: Support method chaining for addGate
 
 ## [0.6.2] - 2019-03-13
 

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -199,6 +199,7 @@ class Circuit {
         connector,
       };
     }
+    return this;
   }
 
   createTransform(U, qubits) {

--- a/packages/qiskit-sim/test/functional/Circuit.js
+++ b/packages/qiskit-sim/test/functional/Circuit.js
@@ -17,8 +17,7 @@ const circuit = new Circuit();
 const circuitMulti = new Circuit({ nQubits: 2 });
 
 circuit.addGate(Gate.h, 0, 0);
-circuitMulti.addGate(Gate.h, 0, 0);
-circuitMulti.addGate(Gate.cx, 1, [0, 1]);
+circuitMulti.addGate(Gate.h, 0, 0).addGate(Gate.cx, 1, [0, 1]);
 
 function checkValid(circ) {
   assert.equal(circ.nQubits, 1);


### PR DESCRIPTION
### Summary
This commit returns `this` from addGate to support method chaining.


### Details and comments
For example:
```js
const c = new Circuit({ nQubits: 1 });
c.addGate('h', 0, 0).addGate('z', 1, 0).addGate('h', 2, 0).run(10);
```
