### PR TITLE
Add createCircuit factory function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `@qiskit/qiskit-sim`: Introduce Gate class
 - `@qiskit/qiskit-sim`: Add the identity (id) gate
+- `@qiskit/qiskit-sim`: Add createCircuit factory function
 
 ### ✏️ Changed
 

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -372,6 +372,13 @@ class Circuit {
 
     return s;
   }
+
+  static createCircuit(qubits) {
+    if (typeof qubits !== 'number')
+      throw new TypeError('The "qubits" argument must be of type number. ' +
+                          `Received ${typeof qubits}`);
+    return new Circuit({nQubits: qubits});
+  }
 }
 
 module.exports = Circuit;

--- a/packages/qiskit-sim/test/functional/Circuit.js
+++ b/packages/qiskit-sim/test/functional/Circuit.js
@@ -100,3 +100,27 @@ describe('sim:Circuit:load', () => {
     checkValid(circuitOther);
   });
 });
+
+describe('sim:Circuit:createCircuit', () => {
+  it('should be able create Circuit using factory function', () => {
+    const c = Circuit.createCircuit(2);
+    assert.equal(c.nQubits, 2);
+  });
+
+  it('should throw a TypeError if qubit argument is not a number', () => {
+    assert.throws(() => {
+      Circuit.createCircuit('a');
+      },
+      {
+        name: 'TypeError',
+        message: 'The "qubits" argument must be of type number. Received string'
+      }
+    );
+  });
+
+  it('should throw an error if qubit argument is undefined', () => {
+    assert.throws(() => {
+      Circuit.createCircuit();
+    });
+  });
+});


### PR DESCRIPTION
### Summary
This commit adds a factory function named createCircuit that takes the
number of qubits as its sole argument.



### Details and comments
The motivation for this is that I've found myself trying to create a new
circuit using new Circuit(3). Having this function allows for just
passing in the number of qubits.
