### PR TITLE
Add dimension parameter to initTransform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update packages links in qiskit-devs
 - `@qiskit/qiskit-sim`: Support method chaining for addGate
 - `@qiskit/qiskit-sim`: Move utility functions to utils
+- `@qiskit/qiskit-sim`: Add dimension parameter to initTransform
 
 ## [0.6.2] - 2019-03-13
 

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -104,14 +104,13 @@ class Circuit {
     return math.pow(2, this.nQubits);
   }
 
-  initTransform() {
+  initTransform(dimension) {
     this.resetTransform();
-    const n = math.pow(2, this.nQubits);
 
-    for (let i = 0; i < n; i += 1) {
+    for (let i = 0; i < dimension; i += 1) {
       this.T[i] = [];
 
-      for (let j = 0; j < n; j += 1) {
+      for (let j = 0; j < dimension; j += 1) {
         this.T[i][j] = 0;
       }
     }
@@ -126,7 +125,7 @@ class Circuit {
       this.state.push(math.complex(0, 0));
     }
 
-    this.initTransform();
+    this.initTransform(numAmplitudes);
   }
 
   numCols() {
@@ -179,7 +178,8 @@ class Circuit {
   }
 
   createTransform(U, qubits) {
-    this.initTransform();
+    const dimension = this.numAmplitudes();
+    this.initTransform(dimension);
 
     const qbts = [];
     // eslint-disable-next-line no-param-reassign
@@ -195,11 +195,10 @@ class Circuit {
       }
     }
 
-    const n = math.pow(2, this.nQubits);
-    let i = n;
+    let i = dimension;
     // eslint-disable-next-line no-cond-assign,no-plusplus
     while (i--) {
-      let j = n;
+      let j = dimension;
 
       // eslint-disable-next-line no-cond-assign,no-plusplus
       while (j--) {


### PR DESCRIPTION
### Summary
Currently initTransform calculates the dimension for the transformation
matrix. This is also done by the methods that call initTranform, init
and createTransform.


### Details and comments
This commit suggests adding a parameter initTransform and avoid
calculating this value multiply times.

