### PR TITLE
Rename qbts to unusedWires in createTransform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### ✏️ Changed
+
+- `@qiskit/qiskit-sim`: Rename qbts to unusedWires in createTransform
+
 ## [0.7.0] - 2019-04-12
 
 ### 🎉 Added

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -181,7 +181,6 @@ class Circuit {
     const dimension = this.numAmplitudes();
     this.initTransform(dimension);
 
-    const qbts = [];
     // eslint-disable-next-line no-param-reassign
     qubits = qubits.slice(0);
     for (let i = 0; i < qubits.length; i += 1) {
@@ -189,9 +188,10 @@ class Circuit {
       qubits[i] = this.nQubits - 1 - qubits[i];
     }
     qubits.reverse();
+    const unusedWires = [];
     for (let i = 0; i < this.nQubits; i += 1) {
       if (qubits.indexOf(i) === -1) {
-        qbts.push(i);
+        unusedWires.push(i);
       }
     }
 
@@ -203,20 +203,22 @@ class Circuit {
       // eslint-disable-next-line no-cond-assign,no-plusplus
       while (j--) {
         let bitsEqual = true;
-        let k = qbts.length;
+        let unusedCount = unusedWires.length;
 
         // eslint-disable-next-line no-cond-assign,no-plusplus
-        while (k--) {
+        while (unusedCount--) {
           // eslint-disable-next-line no-bitwise
-          if ((i & (1 << qbts[k])) !== (j & (1 << qbts[k]))) {
+          const b = 1 << unusedWires[unusedCount];
+          // eslint-disable-next-line no-bitwise
+          if ((i & b) !== (j & b)) {
             bitsEqual = false;
             break;
           }
         }
+        let k = qubits.length;
         if (bitsEqual) {
           let istar = 0;
           let jstar = 0;
-          k = qubits.length;
           // eslint-disable-next-line no-cond-assign,no-plusplus
           while (k--) {
             const q = qubits[k];


### PR DESCRIPTION
### Summary
This commit renames the `qbts` variable in Circuit.createTransform to
`unusedWires` in hopes to make it more understandable.


### Details and comments
My understanding is that this array represents the unused wires
(indexed in opposite order from the qubits/wires passed into the
createTransform function).

For example, a system of 3 qubits and a single hadamard gate:
```console
qubits                                opposite-order
 q[0] ----H--------------------------- q[2]
 q[1] -------------------------------- q[1]
 q[2] -------------------------------- q[0]
```
In this case qubits/wires used by this gate would be [2] and
qbts/unsuedWires would be [0, 1] (using the opposite-order indexing).


