### PR TITLE
Make amplitudes a member of the Circuit class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### ✏️ Changed
 
 - `@qiskit/qiskit-sim`: Rename qbts to unusedWires in createTransform
+- `@qiskit/qiskit-sim`: Make amplitudes a member of the Circuit class
 
 ## [0.7.0] - 2019-04-12
 

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -78,6 +78,7 @@ function decompose(obj) {
 class Circuit {
   constructor(opts = {}) {
     this.nQubits = opts.nQubits || 1;
+    this.amplitudes = math.pow(2, this.nQubits);
     this.customGates = {};
     this.clear();
   }
@@ -101,7 +102,7 @@ class Circuit {
   }
 
   numAmplitudes() {
-    return math.pow(2, this.nQubits);
+    return this.amplitudes;
   }
 
   initTransform(dimension) {
@@ -150,6 +151,7 @@ class Circuit {
 
       if (wire + 1 > this.nQubits) {
         this.nQubits = wire + 1;
+        this.amplitudes = math.pow(2, this.nQubits);
       }
 
       while (this.gates.length < this.nQubits) {
@@ -261,6 +263,7 @@ class Circuit {
 
   load(obj) {
     this.nQubits = obj.nQubits || 1;
+    this.amplitudes = math.pow(2, this.nQubits);
     this.clear();
     this.gates = obj.gates;
     this.customGates = obj.customGates;


### PR DESCRIPTION
### Summary
Make amplitudes a member of the Circuit class


### Details and comments
Currently numAmplitudes is called by init, createTransform, and
stateToString. While stateToString might not be called, init and
createTransform are both called by run (indirectly by applyGate) and the
value calculated twice.

