### PR TITLE
Remove clear() call from Circuit constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `@qiskit/qiskit-sim`: Rename qbts to unusedWires in createTransform
 - `@qiskit/qiskit-sim`: Make amplitudes a member of the Circuit class
+- `@qiskit/qiskit-sim`: Remove clear() call from Circuit constructor
 
 ## [0.7.0] - 2019-04-12
 

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -80,7 +80,9 @@ class Circuit {
     this.nQubits = opts.nQubits || 1;
     this.amplitudes = math.pow(2, this.nQubits);
     this.customGates = {};
-    this.clear();
+    this.gates = [];
+    this.state = [];
+    this.T = [];
   }
 
   resetTransform() {


### PR DESCRIPTION
### Summary
This commit removes the `clear` call from the Circuit constructor and puts
the member initialisation of `gates`, `state`, and `T`, in the constructor
itself.



### Details and comments
The motivation for this is to hopefully clarify the state of a
Circuit making it a little easier to follow when one does not have to
follow the `clear()` -> `reset()` -> `resetTransform()` calls to figure this
out.

