### PR TITLE
Allow for executing the same circuit twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-sim`: Rename qbts to unusedWires in createTransform
 - `@qiskit/qiskit-sim`: Make amplitudes a member of the Circuit class
 - `@qiskit/qiskit-sim`: Remove clear() call from Circuit constructor
+- `@qiskit/qiskit-sim`: Allow for executing the same circuit twice
 
 ## [0.7.0] - 2019-04-12
 

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -90,7 +90,9 @@ class Circuit {
   }
 
   reset() {
-    this.state = [];
+    if (this.state == null) {
+      this.state = [];
+    }
     this.resetTransform();
   }
 
@@ -121,11 +123,13 @@ class Circuit {
 
   init() {
     this.reset();
-    this.state.push(math.complex(1, 0));
     const numAmplitudes = this.numAmplitudes();
 
-    for (let i = 1; i < numAmplitudes; i += 1) {
-      this.state.push(math.complex(0, 0));
+    if (this.state.length === 0) {
+      this.state.push(math.complex(1, 0));
+      for (let i = 1; i < numAmplitudes; i += 1) {
+        this.state.push(math.complex(0, 0));
+      }
     }
 
     this.initTransform(numAmplitudes);
@@ -254,6 +258,7 @@ class Circuit {
       nQubits: this.nQubits,
       gates: this.gates,
       customGates: this.customGates,
+      state: this.state
     };
 
     if (decomposed) {
@@ -269,6 +274,7 @@ class Circuit {
     this.clear();
     this.gates = obj.gates;
     this.customGates = obj.customGates;
+    this.state = obj.state;
   }
 
   getGateAt(column, wire) {

--- a/packages/qiskit-sim/test/functional/Circuit.js
+++ b/packages/qiskit-sim/test/functional/Circuit.js
@@ -65,6 +65,23 @@ describe('sim:Circuit:run', () => {
       { re: 0.7071067811865475, im: 0 },
     ]);
   });
+
+  it('should be possible execute the same circuit twice in a row', () => {
+    const expectedState = [
+      { re: 0.9999999999999998, im: 0 },
+      { re: 0, im: 0 }
+    ];
+
+    const twoGates = Circuit.createCircuit(1);
+    twoGates.addGate(Gate.h, 0, 0).addGate(Gate.h, 1, 0).run();
+    assert.deepEqual(twoGates.state, expectedState);
+
+    const runTwice = Circuit.createCircuit(1);
+    runTwice.addGate(Gate.h, 0, 0);
+    runTwice.run();
+    runTwice.run();
+    assert.deepEqual(runTwice.state, expectedState);
+  });
 });
 
 describe('sim:Circuit:stateToString', () => {


### PR DESCRIPTION
### Summary
This commit adds support for executing the same circuit twice (or more
times) in row with the state from the previous execution being used as
the state for the next execution.


### Details and comments
The motivation for this came out of wanting to executing a hadamard gate
twice, and while it is possible to add two gates and then run it, having
the ability to run the circuit multiple times gives a nice separation
for someone learning about quantum gates (allows for inspecting/logging
the state if one is not comfortable using a debugger for example).

