### PR TITLE
Use Gate.x.name for initial values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- `@qiskit/qiskit-sim`: Use Gate.x.name for initial values
+
+
 ## [0.7.1] - 2019-04-23
 
 ### ✏️ Changed

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -308,7 +308,7 @@ class Circuit {
     if (initialValues) {
       for (let wire = 0; wire < this.nQubits; wire += 1) {
         if (initialValues[wire]) {
-          this.applyGate(Gate.x, [wire]);
+          this.applyGate(Gate.x.name, [wire]);
         }
       }
     }

--- a/packages/qiskit-sim/test/functional/Circuit.js
+++ b/packages/qiskit-sim/test/functional/Circuit.js
@@ -66,6 +66,16 @@ describe('sim:Circuit:run', () => {
     ]);
   });
 
+  it('should not throw Error with initial values', () => {
+    const c = Circuit.createCircuit(2);
+    c.addGate(Gate.h, 0, 0);
+    assert.doesNotThrow( () => {
+      c.run([false, true]);
+    },
+    TypeError
+   );
+  });
+
   it('should be possible execute the same circuit twice in a row', () => {
     const expectedState = [
       { re: 0.9999999999999998, im: 0 },


### PR DESCRIPTION
### Summary
I introduces a bug when adding the Gate class which is that when initial
values are passed into the run method the applyGate should be called
with name of the gate and not the Gate instance.



### Details and comments
Fixes: https://github.com/Qiskit/qiskit-js/issues/51

