### PR TITLE
Make r2 gate use the matrix of the s gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### ✏️ Changed
 
 - `@qiskit/qiskit-sim`: Add phaseShift util function for phase gates
+- `@qiskit/qiskit-sim`: Make r2 gate use the matrix of the s gate
 
 ### 🐛 Fixed
 

--- a/packages/qiskit-sim/lib/gates.js
+++ b/packages/qiskit-sim/lib/gates.js
@@ -60,7 +60,7 @@ Gate.srn = new Gate('srn',
                     [[1 / math.sqrt(2), 0 - 1 / math.sqrt(2)],
                      [1 / math.sqrt(2), 1 / math.sqrt(2)]]);
 Gate.s = new Gate('s', phaseShift(2));
-Gate.r2 = new Gate('r2', phaseShift(2));
+Gate.r2 = new Gate('r2', Gate.s.matrix);
 Gate.r4 = new Gate('r4', phaseShift(4));
 Gate.r8 = new Gate('r8', phaseShift(8));
 Gate.swap = new Gate('swap',


### PR DESCRIPTION
### Summary
Make r2 gate use the matrix of the s gate


### Details and comments
This commit updates the r2 gate to use the unitary matrix of the s gate
instead of redefining it.

