### PR TITLE
Add t gate as an alias for the r4 gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### 🎉 Added
+
+- `@qiskit/qiskit-sim`: Add t gate as an alias for the r4 gate
+
 ### ✏️ Changed
 
 - `@qiskit/qiskit-sim`: Add phaseShift util function for phase gates

--- a/packages/qiskit-sim/lib/gates.js
+++ b/packages/qiskit-sim/lib/gates.js
@@ -63,6 +63,7 @@ Gate.s = new Gate('s', phaseShift(2));
 Gate.r2 = new Gate('r2', phaseShift(2));
 Gate.r4 = new Gate('r4', phaseShift(4));
 Gate.r8 = new Gate('r8', phaseShift(8));
+Gate.t = new Gate('t', Gate.r4.matrix);
 Gate.swap = new Gate('swap',
                      [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]);
 Gate.srswap = new Gate('srswap',

--- a/packages/qiskit-sim/test/functional/gates.js
+++ b/packages/qiskit-sim/test/functional/gates.js
@@ -11,7 +11,7 @@
 
 const assert = require('assert');
 
-const { gates } = require('../..');
+const { gates, Gate } = require('../..');
 
 describe('sim:gates', () => {
   it('should include all supported ones', () =>
@@ -26,6 +26,7 @@ describe('sim:gates', () => {
       'r2',
       'r4',
       'r8',
+      't',
       'swap',
       'srswap',
       'cx',
@@ -38,4 +39,7 @@ describe('sim:gates', () => {
       'cr4',
       'cr8',
     ]));
+  it('t gate should have the same unitary matrix as the r4 gate', () => {
+    assert.deepEqual(Gate.t.matrix, Gate.r4.matrix);
+  });
 });


### PR DESCRIPTION
### Summary
Add t gate as an alias for the r4 gate


### Details and comments
This commit adds a gate named t as an alias for the phase shift PI/4
gate.

