### PR TITLE
Add Gate as option to addGate API in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### 🎉 Added
 
 - `@qiskit/qiskit-sim`: Add t gate as an alias for the r4 gate
+- `@qiskit/qiskit-sim`: Add Gate as option to addGate API in README
 
 ### ✏️ Changed
 

--- a/packages/qiskit-sim/README.md
+++ b/packages/qiskit-sim/README.md
@@ -89,11 +89,11 @@ Gates definition.
 
 * `stateStr` (string) - Human friendly representation of the internal state.
 
-### `circuit.addGate(name, column, wires)`
+### `circuit.addGate(gate, column, wires)`
 
 Add a gate to the circuit.
 
-* `name` (string) - Name of the gate, from `gates` field.
+* `gate` (Gate|string) - Gate instance or name of the gate, from `gates` field.
 * `colum` (number) - Qubit to connect the gate.
 * `wires` (number / [number]) - Gate connections. An array is used for multi-gates.
 


### PR DESCRIPTION
### Summary
Add Gate as option to addGate API in README


### Details and comments
This commit updates the addGate API documentation to include the Gate
instance as an alternative to passing in the gate name as a string.


