### PR TITLE
Add print circuit method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### 🎉 Added
+
+- `@qiskit/qiskit-sim`: Add print circuit method
+
 ## [0.8.0] - 2019-04-25
 
 ### 🎉 Added


### PR DESCRIPTION
### Summary
This commit introduces a print method to the Circuit class. The idea is
to give a visual representation of the quantum circuit.


### Details and comments
The motivation for this is as a learning aid to help understand the
circuit created. The implementation can probably be made more efficient
but I wanted to get some feedback on this feature and if it is
worth pursuing/spending time on (or perhaps it could be useful as is
and developed further as required).

<details>
<summary>Node REPL example:</summary>

```console
> const { Circuit, Gate } = require('./index.js');
undefined

> const c = Circuit.createCircuit(1);
undefined
> c.addGate(Gate.x, 0, 0).print()

          column 0
wire 0 ---[x]-----------

undefined
> c.addGate(Gate.cx, 1, [0, 1]).print()

          column 0      column 1
wire 0 ---[x]-----------[cx]----------
                         |
wire 1 -----------------[*]-----------
 ```
</details>


<details>
<summary>Node example:</summary>

```js
const { Circuit, Gate } = require('./index.js');
const c = Circuit.createCircuit(2);
c.addGate(Gate.x, 0, 0).print()
c.addGate(Gate.cx, 1, [0, 1]).print()
```

```console
$ node example

          column 0
wire 0 ---[x]-----------

wire 1 -----------------


          column 0      column 1
wire 0 ---[x]-----------[cx]----------
                         |
wire 1 -----------------[*]-----------
```
</details>