### PR TITLE
Use spread operator in addGate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### ✏️ Changed
+
+- `@qiskit/qiskit-sim`:   Use spread operator in addGate
+
 ## [0.8.0] - 2019-04-25
 
 ### 🎉 Added

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -143,9 +143,7 @@ class Circuit {
     const wireList = [];
 
     if (Array.isArray(wires)) {
-      for (let i = 0; i < wires.length; i += 1) {
-        wireList.push(wires[i]);
-      }
+      wireList.push(...wires);
     } else {
       wireList.push(wires);
     }


### PR DESCRIPTION
### Summary
Use spread operator in addGate


### Details and comments
This commit uses the spread operator instead of looping over the wires
to populate the wireList.

