### PR TITLE
Add print method to Circuit API documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### 🎉 Added
 
 - `@qiskit/qiskit-sim`: Add print circuit method
+- `@qiskit/qiskit-sim`: Add print method to Circuit API documentation
 
 ## [0.8.0] - 2019-04-25
 

--- a/packages/qiskit-sim/README.md
+++ b/packages/qiskit-sim/README.md
@@ -97,6 +97,13 @@ Add a gate to the circuit.
 * `column` (number) - Qubit to connect the gate.
 * `wires` (number / [number]) - Gate connections. An array is used for multi-gates.
 
+### `circuit.print([writable])`
+
+Prints a visual representation of the circuit to standard out (by default).
+
+* `writable` (object) - Optional [Writable](https://nodejs.org/api/stream.html#stream_writable_streams)
+object which will be written to. Defaults to process.stdout.
+
 ### `circuit.run(input)`
 
 Make the simulation.


### PR DESCRIPTION
### Summary
Add print method to Circuit API documentation


### Details and comments
I forgot to add this as part of https://github.com/Qiskit/qiskit-js/pull/59.