### PR TITLE
Add 'add' method to Circuit class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `@qiskit/qiskit-sim`: Add print circuit method
 - `@qiskit/qiskit-sim`: Add print method to Circuit API documentation
+- `@qiskit/qiskit-sim`: Add 'add' method to Circuit class
 
 ## [0.8.0] - 2019-04-25
 

--- a/packages/qiskit-sim/README.md
+++ b/packages/qiskit-sim/README.md
@@ -19,7 +19,7 @@ npm i @qiskit/sim
 ```js
 const util = require('util');
 
-const sim = require('@qiskit/sim');
+const { Circuit, Gate } = require('@qiskit/sim');
 
 function randomizeInput(nQubits) {
   const input = [];
@@ -34,10 +34,11 @@ function randomizeInput(nQubits) {
   return input;
 }
 
-const circuit = new sim.Circuit({ nQubits: 2 });
+const circuit = Circuit.createCircuit(2);
 
-circuit.addGate(sim.Gate.h, 0, 0);
-circuit.addGate(sim.Gate.cx, 1, [0, 1]);
+circuit.add(Gate.h, 0, 0);
+circuit.add(Gate.cx, 1, [0, 1]);
+circuit.print();
 
 console.log('\nInput randomized (as string):');
 const input = randomizeInput(circuit.nQubits);
@@ -94,6 +95,15 @@ Gates definition.
 Add a gate to the circuit.
 
 * `gate` (Gate|string) - Gate instance or name of the gate, from `gates` field.
+* `column` (number) - Qubit to connect the gate.
+* `wires` (number / [number]) - Gate connections. An array is used for multi-gates.
+
+### `circuit.add(gate, column, wires)`
+
+Add a gate to the circuit. This function is identical to `addGate` but only
+accepts `Gate` instances.
+
+* `gate` (Gate) - Gate instance to add to the circuit.
 * `column` (number) - Qubit to connect the gate.
 * `wires` (number / [number]) - Gate connections. An array is used for multi-gates.
 

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -184,6 +184,14 @@ class Circuit {
     return this;
   }
 
+  add(gate, column, wire) {
+    if (!(gate instanceof Gate)) {
+      throw new TypeError('The "gate" argument must be of type Gate. ' +
+                          `Received ${typeof gate}`);
+    }
+    return this.addGate(gate, column, wire);
+  }
+
 
   createTransform(U, qubits) {
     const dimension = this.numAmplitudes();

--- a/packages/qiskit-sim/test/functional/Circuit.js
+++ b/packages/qiskit-sim/test/functional/Circuit.js
@@ -44,6 +44,26 @@ describe('sim:Circuit:addGate', () => {
   });
 });
 
+describe('sim:Circuit:add', () => {
+  it('should modify the circuit using add ', () => {
+    const c = Circuit.createCircuit(1);
+    c.add(Gate.h, 0, 0);
+    checkValid(circuit);
+  });
+
+  it('should only accept Gate instances ', () => {
+    const c = new Circuit();
+    assert.throws(() => {
+      c.add('h', 0, 0);
+      },
+      {
+        name: 'TypeError',
+        message: 'The "gate" argument must be of type Gate. Received string'
+      }
+    );
+  });
+});
+
 describe('sim:Circuit:run', () => {
   it('should change the internal state for a single gate circuit', () => {
     const input = [false];


### PR DESCRIPTION
### Summary
This commit adds a method named add to the Circuit class which only
accepts Gate class instances as the type of the gate parameter.



### Details and comments
The motivation for that when using a Gate class instance as the input to
the addGate method it reads a little verbose:
```js
circuit.addGate(Gate.h, 0, 0);
```
With this change adding this same gate would become:
```js
circuit.add(Gate.h, 0, 0);
```

