### PR TITLE
Add missing require statements in parser example

### DIFF
--- a/packages/qiskit-qasm/README.md
+++ b/packages/qiskit-qasm/README.md
@@ -18,6 +18,8 @@ npm i @qiskit/qasm
 
 ```js
 const qasm = require('@qiskit/qasm');
+const fs = require('fs');
+const util = require('util');
 
 console.log('Version');
 console.log(qasm.version);

--- a/packages/qiskit-qasm/example.qasm
+++ b/packages/qiskit-qasm/example.qasm
@@ -1,0 +1,7 @@
+IBMQASM 2.0;
+include "qelib1.inc";
+qreg q[1];
+creg c[1];
+
+x q[1];
+measure q -> c;


### PR DESCRIPTION
### Summary
This commit adds the missing fs and util modules from the parser example
in the README.


### Details and comments
Currently just copying and pasting the example code in the README will fail due to the missing imports. This commit also adds a very simple `example.qasm` file to allow for quickly trying the sample code out.

