### PR TITLE
Fix connection bug in printCircuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-sim`: Add print method to Circuit API documentation
 - `@qiskit/qiskit-sim`: Add 'add' method to Circuit class
 
+> - 🐛 **Fixed**: for any bug fixes.
+
+- `@qiskit/qiskit-sim`: Fix connection bug in printCircuit
+
 ## [0.8.0] - 2019-04-25
 
 ### 🎉 Added

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -407,6 +407,7 @@ class Circuit {
     writable.write(columnHeader);
     writable.write('\n');
 
+    const connStarted = Array(this.numCols()).fill(false);
     for (let wire = 0; wire < this.nQubits; wire += 1) {
       writable.write(`wire ${wire} `.padEnd(columnLen, '-'));
       let wireOutput = '';
@@ -419,9 +420,11 @@ class Circuit {
             const c = connections.get(gate.id);
             if (c.from === wire) {
               c.fromVisited = true;
+              connStarted[column] = true;
             }
             if (c.to === wire) {
               c.toVisited = true;
+              connStarted[column] = true;
             }
 
             if (c.fromVisited === true && c.toVisited === true) {
@@ -432,7 +435,7 @@ class Circuit {
             } else {
               connOutput += ` |`;
             }
-          }  else {
+          }  else if (connStarted[column]) {
               connOutput += ` |`;
           }
         }

--- a/packages/qiskit-sim/test/functional/Circuit.js
+++ b/packages/qiskit-sim/test/functional/Circuit.js
@@ -241,4 +241,21 @@ describe('sim:Circuit:print', () => {
     assert.strictEqual(stripWhitespace(result), stripWhitespace(expected));
   });
 
+  it('should print circuit with connections over mutiple wires', () => {
+    const expected = `
+                column 0      column 1
+      wire 0 -------------------------------
+
+      wire 1 ---[x]-----------[cx]----------
+                               |
+      wire 2 -----------------[*]-----------
+
+      wire 3 -------------------------------`;
+
+    Circuit.createCircuit(4).addGate(Gate.x, 0, 1)
+                            .addGate(Gate.cx, 1, [1, 2])
+                            .print(writable);
+    assert.strictEqual(stripWhitespace(result), stripWhitespace(expected));
+  });
+
 });


### PR DESCRIPTION
### Summary
Fix connection bug in printCircuit


### Details and comments
This commit fixes a bug in printCircuit where connection between two
gates would be displayed before the start gate. For example, the
following could be printed which is incorrect:
```console
          column 0      column 1
wire 0 -------------------------------
                         |
wire 1 ---[x]-----------[cx]----------
                         |
wire 2 -----------------[*]-----------

wire 3 -------------------------------
```


