### PR TITLE
 Add fromQasm/fromQasmFile functions to Circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-sim`: Add print method to Circuit API documentation
 - `@qiskit/qiskit-sim`: Add 'add' method to Circuit class
 - `@qiskit/qiskit-qasm`: Add name to the gate type in qasm parser
+- `@qiskit/qiskit-sim`: Add fromQasm/fromQasmFile functions to Circuit
 
 > - 🐛 **Fixed**: for any bug fixes.
 

--- a/packages/qiskit-sim/lib/Circuit.js
+++ b/packages/qiskit-sim/lib/Circuit.js
@@ -12,6 +12,8 @@
 'use strict';
 
 const math = require('mathjs');
+const fs = require('fs');
+const { Parser } = require('@qiskit/qasm');
 
 const utils = require('./utils');
 const { Gate, gates } = require('./gates');
@@ -435,8 +437,8 @@ class Circuit {
             } else {
               connOutput += ` |`;
             }
-          }  else if (connStarted[column]) {
-              connOutput += ` |`;
+          } else if (connStarted[column]) {
+            connOutput += ` |`;
           }
         }
 
@@ -467,6 +469,48 @@ class Circuit {
                           `Received ${typeof qubits}`);
     return new Circuit({nQubits: qubits});
   }
-}
 
+  static fromQasm(qasm) {
+    const parser = new Parser();
+    const parsed = parser.parse(qasm);
+    let qubits = 0;
+    const wiresMap = new Map();
+    const gatesArr = [];
+
+    parsed.forEach((entry) => {
+      if (entry.type === 'qubit') {
+        wiresMap.set(entry.identifier, {offset: qubits, columnCount: 0});
+        qubits += parseInt(entry.number, 10);
+      }
+
+      if (entry.type === 'gate') {
+        gatesArr.push(entry);
+      }
+    });
+
+    const circuit = Circuit.createCircuit(qubits);
+
+    for (let i = 0; i < gatesArr.length; i += 1) {
+      const wires = [];
+      const gate = gatesArr[i];
+      let column;
+      for (let y = 0; y < gate.identifiers.length; y += 1) {
+        const id = gate.identifiers[y];
+        if (y === 0) {
+          column = wiresMap.get(id.name).columnCount;
+          wiresMap.get(id.name).columnCount += 1;
+        }
+        const { index } = id
+        const { offset } = wiresMap.get(id.name);
+        wires.push(parseInt(offset, 10) + parseInt(index, 10));
+      }
+      circuit.addGate(gate.name, column, wires);
+    }
+    return circuit;
+  }
+
+  static fromQasmFile(path) {
+    return Circuit.fromQasm(fs.readFileSync(path, {encoding:'utf8'}));
+  }
+}
 module.exports = Circuit;

--- a/packages/qiskit-sim/package.json
+++ b/packages/qiskit-sim/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@qiskit/utils": "^0.8.0",
+    "@qiskit/qasm": "^0.8.0",
     "mathjs": "^5.9.0"
   },
   "engines": {


### PR DESCRIPTION
### Summary
This pull request adds a suggestion for a static function named fromQasm to the Circuit class which creates a Circuit from QASM source string or file.

### Details and comments
This pull request contains two commit, one to qiskit-qasm and one to qiskit-sim. qiskit-sim depends on the update to qiskit-qasm and currently to test this, qiskit-qasm has to be linked:
```console
$ npm link ../qiskit-qasm/
```

Example usage:
```console
$ node -p <<'HERE'
  const { Circuit, Gate } = require('./index.js');

  const qasm = `
    OPENQASM 2.0;
    include "qelib1.inc";

    qreg q[2];
    creg c[2];

    x q[0];
    cx q[0],q[1];
    measure q[0] -> c[0];
    measure q[1] -> c[1];
  `;

  const c = Circuit.fromQasm(qasm);
  c.print();

HERE
```
Output:
```console
          column 0      column 1
wire 0 ---[x]-----------[cx]----------
                         |
wire 1 -----------------[*]-----------
```
