### PR TITLE
Add name to the gate type in qasm parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-sim`: Add print circuit method
 - `@qiskit/qiskit-sim`: Add print method to Circuit API documentation
 - `@qiskit/qiskit-sim`: Add 'add' method to Circuit class
+- `@qiskit/qiskit-qasm`: Add name to the gate type in qasm parser
 
 > - 🐛 **Fixed**: for any bug fixes.
 

--- a/packages/qiskit-qasm/__snapshots__/parser.test.js
+++ b/packages/qiskit-qasm/__snapshots__/parser.test.js
@@ -54,7 +54,8 @@ exports['qasm:parse should work with "include" 1'] = [
     "number": "5"
   },
   {
-    "type": "x",
+    "type": "gate",
+    "name": "x",
     "identifiers": [
       {
         "name": "q",
@@ -105,7 +106,8 @@ exports['qasm:parse should fail with "include" 1'] = [
     "number": "1"
   },
   {
-    "type": "x",
+    "type": "gate",
+    "name": "x",
     "identifiers": [
       {
         "name": "q",

--- a/packages/qiskit-qasm/lib/grammar.jison
+++ b/packages/qiskit-qasm/lib/grammar.jison
@@ -147,7 +147,8 @@
 
   function buildGate(name, identifiers, params, qelib, line) {
     const gate = {
-      type: name,
+      type: 'gate',
+      name: name,
       identifiers
     };
 


### PR DESCRIPTION
### Summary
This commit updates the gate type in grammar to include a name and
instead set type to 'gate'.


### Details and comments
The motivation for this is a follow up commit where the type can be used
to collect all the gates from a parsed QASM file and the assemble it
into a qiskit-sim Circuit.

