### PR TITLE
Use QasmError for qasm error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 > - ✏️ **Changed**: for changes in existing functionality.
 
 - `@qiskit/qiskit-qasm`: Make QasmError a class
-
+- `@qiskit/qiskit-qasm`: Use QasmError for jison error handling
 
 ## [0.9.0] - 2019-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+> - ✏️ **Changed**: for changes in existing functionality.
+
+- `@qiskit/qiskit-qasm`: Make QasmError a class
+
+
 ## [0.9.0] - 2019-05-13
 
 ### ✏️ Changed

--- a/packages/qiskit-qasm/lib/Parser.js
+++ b/packages/qiskit-qasm/lib/Parser.js
@@ -18,7 +18,7 @@ const utils = require('./utils');
 
 const dbg = utils.dbg(__filename);
 
-// const QasmError = require('./QasmError');
+const QasmError = require('./QasmError');
 
 // TODO: Do async?
 const bnf = fs.readFileSync(path.resolve(__dirname, 'grammar.jison'), 'utf8');
@@ -49,9 +49,10 @@ class Parser {
     try {
       res = parser.parse(circuit, this.qelibParsed);
     } catch (err) {
-      // TODO: Use our custom error
-      // throw new QasmError('')
-      throw err;
+      if (err instanceof QasmError) {
+        throw err;
+      }
+      throw new QasmError(err.message)
     }
 
     return res;

--- a/packages/qiskit-qasm/lib/QasmError.js
+++ b/packages/qiskit-qasm/lib/QasmError.js
@@ -9,37 +9,33 @@
 
 'use strict';
 
-const util = require('util');
+class QasmError extends Error {
 
-function QasmError(msg, opts = {}) {
-  Error.captureStackTrace(this, this.constructor);
+  constructor(message, opts = {}) {
+    if (!message) {
+      throw new TypeError('Required param: message');
+    }
+    super(message);
+    this.name = 'QasmError';
 
-  this.name = this.constructor.name;
-
-  if (!msg) {
-    throw new Error('Required param: msg');
+    // TODO: Review: error code, etc? If coming from jison X ours Y
+    if (opts.line) {
+      this.line = opts.line;
+    }
+    if (opts.column) {
+      this.column = opts.column;
+    }
+    if (opts.text) {
+      this.text = opts.text;
+    }
+    if (opts.token) {
+      this.token = opts.token;
+    }
+    if (opts.expected) {
+      this.expected = opts.expected;
+    }
   }
 
-  this.message = msg;
-
-  // TODO: Review: error code, etc? If coming from jison X ours Y
-  if (opts.line) {
-    this.line = opts.line;
-  }
-  if (opts.column) {
-    this.column = opts.column;
-  }
-  if (opts.text) {
-    this.text = opts.text;
-  }
-  if (opts.token) {
-    this.token = opts.token;
-  }
-  if (opts.expected) {
-    this.expected = opts.expected;
-  }
 }
-
-util.inherits(QasmError, Error);
 
 module.exports = QasmError;

--- a/packages/qiskit-qasm/lib/QasmError.js
+++ b/packages/qiskit-qasm/lib/QasmError.js
@@ -21,6 +21,7 @@ class QasmError extends Error {
     // TODO: Review: error code, etc? If coming from jison X ours Y
     if (opts.line) {
       this.line = opts.line;
+      this.message += ` (line:${this.line})`;
     }
     if (opts.column) {
       this.column = opts.column;

--- a/packages/qiskit-qasm/test/functional/parser.test.js
+++ b/packages/qiskit-qasm/test/functional/parser.test.js
@@ -153,4 +153,37 @@ describe('qasm:parse', () => {
 
     utilsTest.shot(parser.parse(circuit));
   });
+
+  it('should throw QasmError if gate is not defined', () => {
+    parser = new Parser();
+    const circuit =
+      'OPENQASM 2.0;\n' +
+      'qreg q[1];\n' +
+      'creg c[1];\n' +
+      'a q[0];';
+
+    assert.throws(() => {
+      utilsTest.shot(parser.parse(circuit));
+    }, {
+      name: 'QasmError',
+      message: 'Gate a is not defined (line:4)'
+    });
+  });
+
+  it('should throw wrap Jison Error as a QasmError', () => {
+    parser = new Parser();
+    const circuit =
+      'OPENQASM 2.0;\n' +
+      'include "bogus";\n';
+
+    assert.throws(() => {
+      utilsTest.shot(parser.parse(circuit));
+    }, {
+      name: 'QasmError',
+      message: 'Lexical error on line 2. ' +
+               'Unrecognized text.\n' +
+               '...ENQASM 2.0;include "bogus";\n' +
+               '----------------------^'
+    });
+  });
 });

--- a/packages/qiskit-qasm/test/functional/qasmError.test.js
+++ b/packages/qiskit-qasm/test/functional/qasmError.test.js
@@ -69,6 +69,6 @@ describe('qasm:QasmError', () => {
   });
 
   it('should fail without a message', () => {
-    assert.throws(() => new QasmError(), /Required param: msg/);
+    assert.throws(() => new QasmError(), /Required param: message/);
   });
 });

--- a/packages/qiskit-qasm/test/functional/qasmError.test.js
+++ b/packages/qiskit-qasm/test/functional/qasmError.test.js
@@ -27,7 +27,7 @@ describe('qasm:QasmError', () => {
     const err = new QasmError(msg, opts);
 
     assert.equal(err.name, 'QasmError');
-    assert.equal(err.message, msg);
+    assert.equal(err.message, `${msg} (line:${opts.line})`);
     assert.equal(typeof err.stack, 'string');
     assert.equal(err.line, 24);
     assert.equal(err.column, 5);
@@ -46,7 +46,7 @@ describe('qasm:QasmError', () => {
 
     assert.equal(err.name, 'QasmError');
     assert.equal(typeof err.stack, 'string');
-    assert.equal(err.message, msg);
+    assert.equal(err.message, `${msg} (line:${opts.line})`);
     assert.equal(err.line, 24);
     assert.equal(err.column, undefined);
     assert.equal(err.text, undefined);


### PR DESCRIPTION
### Summary
This contains two commits that make QasmError into a class and start using it for error handling when parsing using jison. 

### Details and comments
For an example of usage see [parser.test.js](https://github.com/Qiskit/qiskit-js/compare/master...danbev:qasm-error?expand=1#diff-e00c52f8332212ba2d17b574145643d9). Currently only the line number is added to the error but more details can be added.


