### PR TITLE
Make parser a member of class Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `@qiskit/qiskit-qasm`: Make QasmError a class
 - `@qiskit/qiskit-qasm`: Use QasmError for jison error handling
+- `@qiskit/qiskit-qasm`: Make parser a member of class Parser
 
 ## [0.9.0] - 2019-05-13
 

--- a/packages/qiskit-qasm/lib/Parser.js
+++ b/packages/qiskit-qasm/lib/Parser.js
@@ -22,12 +22,11 @@ const QasmError = require('./QasmError');
 
 // TODO: Do async?
 const bnf = fs.readFileSync(path.resolve(__dirname, 'grammar.jison'), 'utf8');
-let parser;
 
 class Parser {
   constructor(opts = {}) {
     dbg('Starting', opts);
-    parser = new jison.Parser(bnf);
+    this.parser = new jison.Parser(bnf);
 
     if (opts.core !== false) {
       // TODO: Parse all core libraries (when we have more)
@@ -35,7 +34,7 @@ class Parser {
         path.resolve(__dirname, '../core/qelib1.inc'),
         'utf8',
       );
-      this.qelibParsed = parser.parse(qelib1);
+      this.qelibParsed = this.parser.parse(qelib1);
     }
   }
 
@@ -47,7 +46,7 @@ class Parser {
     let res;
 
     try {
-      res = parser.parse(circuit, this.qelibParsed);
+      res = this.parser.parse(circuit, this.qelibParsed);
     } catch (err) {
       if (err instanceof QasmError) {
         throw err;


### PR DESCRIPTION
### Summary
Make parser a member of class Parser

### Details and comments
Currently parser is not a member of the Parser class and it looks like
the intention was to share it with all instances of class Parser. But it
also gets re-assigned in the constructor each time a new instance is
created. This commit makes parser a member instead, and perhaps a follow
up commit can take a look at sharing the parser (a quick test showed
that is was not as simple as I hoped).
