### PR TITLE
Use TypeError as error for incorrect type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `@qiskit/qiskit-qasm`: Make QasmError a class
 - `@qiskit/qiskit-qasm`: Use QasmError for jison error handling
+- `@qiskit/qiskit-qasm`: Use TypeError as error for incorrect type
 
 ## [0.9.0] - 2019-05-13
 

--- a/packages/qiskit-qasm/lib/Parser.js
+++ b/packages/qiskit-qasm/lib/Parser.js
@@ -41,7 +41,7 @@ class Parser {
 
   parse(circuit) {
     if (!circuit) {
-      throw new Error('Required param: circuit');
+      throw new TypeError('Required param: circuit');
     }
 
     let res;


### PR DESCRIPTION
### Summary
Use TypeError as error for incorrect type


### Details and comments
This is to make it consistent with other parts of the code base (at
least the parts I've seen that is) that use TypeError when an incorrect
type is passed to a function.

