### PR TITLE
add gate to gates map in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-qasm`: Make parser a member of class Parser
 - `@qiskit/qiskit-qasm`: Use TypeError as error for incorrect type
 - `@qiskit/qiskit-sim`: add prettyMatrix method to Gate class
+- `@qiskit/qiskit-sim`: add gates to gates map in constructor
 
 ## [0.9.0] - 2019-05-13
 

--- a/packages/qiskit-sim/lib/gates.js
+++ b/packages/qiskit-sim/lib/gates.js
@@ -42,10 +42,15 @@ const buildControlled = Gate => {
 const phaseShift = shift =>
   [[1, 0], [0, math.pow(math.e, math.multiply(math.i, math.PI / shift))]];
 
+const gates = new Map();
+
 class Gate {
   constructor(name, matrix) {
     this.name = name;
     this.matrix = matrix;
+    if (!gates.has(name)) {
+      gates.set(name, this);
+    }
   }
 
   prettyMatrix() {
@@ -98,8 +103,6 @@ Gate.cs = new Gate('cs', buildControlled(Gate.s));
 Gate.cr2 = new Gate('cr2', buildControlled(Gate.r2));
 Gate.cr4 = new Gate('cr4', buildControlled(Gate.r4));
 Gate.cr8 = new Gate('cr8', buildControlled(Gate.r8));
-
-const gates = new Map(Object.entries(Gate));
 
 module.exports = {
   Gate,

--- a/packages/qiskit-sim/test/functional/gates.js
+++ b/packages/qiskit-sim/test/functional/gates.js
@@ -50,4 +50,9 @@ describe('sim:gates', () => {
                      '[0, 0, 1, 0]\n';
     assert.strictEqual(Gate.cx.prettyMatrix(), expected);
   });
+
+  it('custom gate should be added to gates map', () => {
+    const custom = new Gate('custom', [[1, 0], [0, 1]]);
+    assert.ok(gates.has(custom.name));
+  });
 });


### PR DESCRIPTION
### Summary
This commit updates the Gate constructor to add the gate created to the
gates map if it does not exist.


### Details and comments
The motivation for this was that when adding a custom gate it would not
be added to the gates map and hence an error would be thrown when trying
to execute the circuit.

