### PR TITLE
make registers const in grammar.jison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-sim`: add gates to gates map in constructor
 - `@qiskit/qiskit-sim`: remove unused addGate function in grammar.jison
 - `@qiskit/qiskit-sim`: allow custom gates to be overwritten
+- `@qiskit/qiskit-qasm`: make registers const in grammar.jison
 
 ## [0.9.0] - 2019-05-13
 

--- a/packages/qiskit-qasm/lib/grammar.jison
+++ b/packages/qiskit-qasm/lib/grammar.jison
@@ -71,7 +71,7 @@
 
   // List of register definitionsutil
   const externalFuncs = ['sin', 'cos', 'tan', 'exp', 'ln', 'sqrt'];
-  var registers = [];
+  const registers = [];
 
   function launchError(line, msg) {
       throw new QasmError(msg, {line: line});


### PR DESCRIPTION
### Summary
make registers const in grammar.jison


### Details and comments
This commit makes the registers array const for consistency with the
other variables in the helpers section.
