### PR TITLE
add name to root package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,5 @@
 {
+  "name": "qiskit-js",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "qiskit-js",
   "scripts": {
     "start": "node packages/qiskit/bin",
     "install": "lerna bootstrap",


### PR DESCRIPTION
### Summary
add name to root package.json

### Details and comments
This commit adds a name property to package.json in an attempt to fix
the build error that currently occurs when running the npm ci target.
