### PR TITLE
fix indentation in grammer.jison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-sim`: remove unused addGate function in grammar.jison
 - `@qiskit/qiskit-sim`: allow custom gates to be overwritten
 - `@qiskit/qiskit-qasm`: make registers const in grammar.jison
+- `@qiskit/qiskit-qasm`: fix indentation in grammer.jison
 
 ## [0.9.0] - 2019-05-13
 

--- a/packages/qiskit-qasm/lib/grammar.jison
+++ b/packages/qiskit-qasm/lib/grammar.jison
@@ -74,7 +74,7 @@
   const registers = [];
 
   function launchError(line, msg) {
-      throw new QasmError(msg, {line: line});
+    throw new QasmError(msg, {line: line});
   }
 
   function addRegister(register, line) {
@@ -145,11 +145,11 @@
 
     // The first time (to parse the standard library - qelib) we dont pass it.
     if (qelib) {
-        const defined = lodash.find(qelib, { name }); 
+      const defined = lodash.find(qelib, { name });
 
-        if (!defined) {
-            launchError(line, `Gate ${name} is not defined`);
-        }
+      if (!defined) {
+        launchError(line, `Gate ${name} is not defined`);
+      }
     }
 
     if (params) { gate.params = params; }
@@ -368,7 +368,7 @@ Unary
     | Id '(' Expression ')'
       {
         if (!lodash.includes(externalFuncs, $Id)) {
-            launchError(@Id.first_line, `Illegal external function call: ${$Id}`);
+          launchError(@Id.first_line, `Illegal external function call: ${$Id}`);
         }
 
         $$ = `${$Expression}(${$Id})`;


### PR DESCRIPTION
### Summary
fix indentation in grammer.jison


### Details and comments
This commit makes the indentation of javascript in grammar.jison consistent.
