### PR TITLE
fix minor typo in parse.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-sim`: allow custom gates to be overwritten
 - `@qiskit/qiskit-qasm`: make registers const in grammar.jison
 - `@qiskit/qiskit-qasm`: fix indentation in grammer.jison
+- `@qiskit/qiskit-bin`: fix minor typo in parse.js
 
 ## [0.9.0] - 2019-05-13
 

--- a/packages/qiskit/bin/cmds/parse.js
+++ b/packages/qiskit/bin/cmds/parse.js
@@ -38,7 +38,7 @@ exports.builder = {
 
 exports.handler = argv => {
   logger.title(qiskit.version);
-  logger.bold('\n\nWARNING: Partial implementetation for now\n\n');
+  logger.bold('\n\nWARNING: Partial implementation for now\n\n');
 
   dbg('Starting, args', argv);
 


### PR DESCRIPTION
### Summary
fix minor typo in parse.js


### Details and comments
Just a correction of the warning message that is displayed.
