### PR TITLE
support comments in grammar.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-sim`: allow custom gates to be overwritten
 - `@qiskit/qiskit-qasm`: make registers const in grammar.jison
 - `@qiskit/qiskit-qasm`: fix indentation in grammer.jison
+- `@qiskit/qiskit-qasm`: support comments in grammar.js
 
 ## [0.9.0] - 2019-05-13
 

--- a/packages/qiskit-qasm/__snapshots__/parser.test.js
+++ b/packages/qiskit-qasm/__snapshots__/parser.test.js
@@ -183,3 +183,21 @@ exports['qasm:parse should work with OPAQUE gate (3) 1'] = [
     ]
   }
 ]
+
+exports['qasm:parse should not ignore comments 1'] = [
+  {
+    "type": "comment",
+    "value": "// Example QASM",
+    "line": 0
+  },
+  {
+    "type": "qubit",
+    "identifier": "q",
+    "number": "1"
+  },
+  {
+    "type": "clbit",
+    "identifier": "c",
+    "number": "1"
+  }
+]

--- a/packages/qiskit-qasm/test/functional/parser.test.js
+++ b/packages/qiskit-qasm/test/functional/parser.test.js
@@ -186,4 +186,16 @@ describe('qasm:parse', () => {
                '----------------------^'
     });
   });
+
+  it('should not ignore comments', () => {
+    parser = new Parser();
+    const circuit =
+      '// Example QASM\n' +
+      'OPENQASM 2.0;\n' +
+      'qreg q[1];\n' +
+      'creg c[1];\n';
+
+    utilsTest.shot(parser.parse(circuit));
+  });
+
 });


### PR DESCRIPTION

### Summary
support comments in grammar.js


### Details and comments
This commit adds support for comments in grammar.js.

The motivation of this is somewhat of a long shot. When using the IBM
Quantum Experience and the QASM editor, if one adds comments to the
code then these are removed upon saving. It would be nice if these were
saved and is why this commit came about. I don't know anything about how
or if this is actually used for the Quantum Experience but thought it
would be worth a try. There is probably more cleaning up to be done and
additional test to be added but I wanted to get some feedback on this
before proceeding.

Example with comments:
```console
$ cat example.qasm
// First Quantum Circuit
IBMQASM 2.0;
include "qelib1.inc";
// quantum registers
qreg q[1];
// classic registers
creg c[1];

x q[1];
measure q -> c;
```
Output:
```console
[ { type: 'comment', value: '// First Quantum Circuit', line: 0 },
  { type: 'comment', value: '// quantum registers', line: 3 },
  { type: 'qubit', identifier: 'q', number: '1' },
  { type: 'comment', value: '// classic registers', line: 5 },
  { type: 'clbit', identifier: 'c', number: '1' },
  { type: 'gate',
    name: 'x',
    identifiers: [ { name: 'q', index: '1' } ] },
  { type: 'measure', qreg: { name: 'q' }, creg: { name: 'c' } } ]
```

