### PR TITLE
add core directory to files in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-sim`: allow custom gates to be overwritten
 - `@qiskit/qiskit-qasm`: make registers const in grammar.jison
 - `@qiskit/qiskit-qasm`: fix indentation in grammer.jison
+- `@qiskit/qiskit-qasm`: add core director to files in package.json
 
 ## [0.9.0] - 2019-05-13
 

--- a/packages/qiskit-qasm/package.json
+++ b/packages/qiskit-qasm/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "lib",
-    "index.js"
+    "index.js",
+    "core"
   ],
   "scripts": {
     "deps": "depcheck",


### PR DESCRIPTION
### Summary
add core director to files in package.json


### Details and comments
Currently, the core directory is not included in the published npm
module which will lead to the following error:
```console
$ node index.js
QASM Version:  0.9.0
fs.js:126
    throw err;
    ^

Error: ENOTDIR: not a directory, open
'qiskit-parser-issue/node_modules/@qiskit/qasm/core/qelib1.inc'
    at Object.openSync (fs.js:447:3)
    at Object.readFileSync (fs.js:349:35)
    at new Parser
       (/qiskit-parser-issue/node_modules/@qiskit/qasm/lib/Parser.js:34:25)
    at Object.<anonymous> (/qiskit-parser-issue/index.js:18:16)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10)
    at internal/main/run_main_module.js:17:11 {
  errno: -20,
  syscall: 'open',
  code: 'ENOTDIR',
  path: '/qiskit-parser-issue/node_modules/@qiskit/qasm/core/qelib1.inc'
```
This commit adds the core directory package.json.

Steps to reproduce
package.json:
```console
$ cat package.json
{
  "name": "qiskit-parser-issue",
  "version": "0.0.1",
  "license": "Apache-2.0",
  "dependencies": {
    "qiskit": "^0.9.0"
  }
}
```
```console
$ cat index.js
const qiskit = require('qiskit');
const qasm = qiskit.qasm;
const sim = qiskit.sim;
const Circuit = sim.Circuit;

const const0 = `
IBMQASM 2.0;
include "qelib1.inc";
qreg q[1];
creg c[1];

x q[1];
measure q -> c;
`;

const parser = new qasm.Parser();
const p = parser.parse(const0);
console.log(p);
```
```console
$ node index.js
```

A workaround would be:
```console
$ mkdir node_modules/@qiskit/qasm/core
$ cp /path/to/core/qelib1.inc node_modules/@qiskit/qasm/core/
```

