### PR TITLE
remove init script from package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-sim`: add deutsch-oracle example
 
 > - ✏️ **Changed**: for changes in existing functionality.
+- `examples/webpack`: remove init script from package.json
 
 - `@qiskit/qiskit-qasm`: Make QasmError a class
 - `@qiskit/qiskit-qasm`: Use QasmError for jison error handling

--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -5,12 +5,7 @@ parser can be used in a browser environment.
 ### Install
 ```console
 $ npm i
-$ npm run init
 ```
-The init run-script is only required because the current version of qiskit/qasm
-does not distribute the `qelib1.inc` file. This has been fixed and will not
-be required in the future.
-
 ### Build
 ```
 $ npm run build

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "build": "webpack",
-    "init": "mkdir node_modules/@qiskit/qasm/core ; cp ../../packages/qiskit-qasm/core/qelib1.inc node_modules/@qiskit/qasm/core"
+    "build": "webpack"
   },
   "files": [
     "package.json",
@@ -22,7 +21,7 @@
     "webpack-cli": "^3.3.6"
   },
   "dependencies": {
-    "@qiskit/sim": "^0.9.0"
+    "@qiskit/sim": "^0.10.0"
   },
   "type": "module"
 }


### PR DESCRIPTION
### Summary
remove init script from package.json

### Details and comments

This commit removes the init script which was required for @qiskit/qasm
0.9.0 where `qelib.inc` was not included in the published modules. With
the next release this will be fixed and the example should work
standalone.

Fixes: https://github.com/Qiskit/qiskit-js/issues/86

@jesusprubio Could we do a release? 