### PR TITLE
fix qiskit-cloud integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@qiskit/qiskit-qasm`: add core director to files in package.json
 - `@qiskit/qiskit-bin`: fix minor typo in parse.js
 
+
+> - 🐛 **Fixed**: for any bug fixes.
+
+- `@qiskit/qiskit-cloud`: fix qiskit-cloud integration tests
+
 ## [0.9.0] - 2019-05-13
 
 ### ✏️ Changed

--- a/packages/qiskit-cloud/test/functional/2-backend.js
+++ b/packages/qiskit-cloud/test/functional/2-backend.js
@@ -117,6 +117,7 @@ const expectedKeys = [
   'status',
   'serialNumber',
   'description',
+  'attributes',
   'gateSet',
   'basisGates',
   'onlineDate',
@@ -165,6 +166,7 @@ describe('cloud:backend', () => {
 
     // TODO: Cloning to fix API inconsistency.
     const expectedFix = expectedKeys.slice(0);
+    expectedFix.splice(5, 1);
     expectedFix.splice(10, 1);
 
     assert.deepEqual(Object.keys(res), expectedFix);
@@ -196,7 +198,7 @@ describe('cloud:backends', () => {
 
     const res = await global.qiskit.cloud.backends();
 
-    assert.equal(res.length, 4);
+    assert.equal(res.length, 5);
     assert.deepEqual(Object.keys(res[0]), expectedKeys);
   });
 

--- a/packages/qiskit-cloud/test/functional/3-credits.js
+++ b/packages/qiskit-cloud/test/functional/3-credits.js
@@ -29,7 +29,7 @@ describe('cloud:credits', () => {
 
     const res = await global.qiskit.cloud.credits();
 
-    assert.deepEqual(Object.keys(res), ['remaining', 'maxUserType']);
+    assert.deepEqual(Object.keys(res).sort(), ['maxUserType', 'remaining']);
     assert.equal(typeof res.remaining, 'number');
     assert.equal(typeof res.maxUserType, 'number');
   });


### PR DESCRIPTION
### Summary
fix qiskit-cloud integration tests


### Details and comments
This commit applies fixes to the cloud tests that connect to IBM Q by
running the test with the QK environment variable set:
```
$ QX_KEY=<API_TOKEN> npm t
```
There are still 3 failing tests which return a 400:
```console
 3 failing

  1) algo:ibm:random
       should return a jobId:
     Error: GENERIC_ERROR
      at request (/qiskit-js/packages/qiskit-cloud/lib/request.js:45:13)
      at processTicksAndRejections (internal/process/task_queues.js:89:5)

  2) algo:ibm:result
       should return the result passing jobId:
     TypeError: The "jobId" parameter is mandatory (string)
      at Object.module.exports.result (index.js:75:11)
      at Context.t (test/functional.js:84:28)
      at processImmediate (internal/timers.js:439:21)

  3) algo:ibm:genBin
       should return a jobId:
     Error: GENERIC_ERROR
      at request (/qiskit-js/packages/qiskit-cloud/lib/request.js:45:13)
      at processTicksAndRejections (internal/process/task_queues.js:89:5)

Doing a search I found that this is a connection error but I'm able to
get a response from the server using a standalone example (taken from
the README.md) but I also get the same error with it. Opening this to
get some feedback and hopefully any pointer to what the issue might be.
```

