### PR TITLE
release of 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.10.0] - 2019-09-05
+
 > - 🎉 **Added**: for new features.
 - `examples/webpack`: Add webpack example
 - `@qiskit/qiskit-sim`: add deutsch-oracle example
@@ -310,7 +312,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Change in lerna setup to allow markdown files in npm.
 - Travis badge in the main README file.
 
-[unreleased]: https://github.com/Qiskit/qiskit-js/compare/v0.9.0...HEAD
+[unreleased]: https://github.com/Qiskit/qiskit-js/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/Qiskit/qiskit-js/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Qiskit/qiskit-js/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Qiskit/qiskit-js/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/Qiskit/qiskit-js/compare/v0.7.0...v0.7.1


### PR DESCRIPTION
### Summary
Just opening this PR for some visibility that I'm actually working on it and not forgotten about it. 
I'm currently trying to get the all the tests to pass successfully before releasing.


### Details and comments
The following tests are failing:
<details>
<summary>test-algo-ibm</summary>

```console
$ QX_KEY=<API_TOKEN> npm run test-algo-ibm

> qiskit-js@ test-algo-ibm /Users/danielbevenius/work/machine-learning/qiskit-js
> lerna run test --scope @qiskit/algo-ibm

lerna notice cli v3.14.1
lerna info filter [ '@qiskit/algo-ibm' ]
lerna info Executing command in 1 package: "npm run test"
lerna ERR! npm run test exited 3 in '@qiskit/algo-ibm'
lerna ERR! npm run test stdout:

> @qiskit/algo-ibm@0.9.0 test /Users/danielbevenius/work/machine-learning/qiskit-js/packages/qiskit-algo-ibm
> mocha --recursive test --timeout 20000 --color



  algo:ibm:api
    ✓ should include all documented items
    ✓ should return the the correct result for its methods

  algo:ibm:version
    ✓ should be correct

  algo:ibm:random
    1) should return a jobId

  algo:ibm:result
    2) should return the result passing jobId

  algo:ibm:genBin
    3) should return a jobId

  algo:ibm:buildCircuit
    ✓ should return a circuit for the default lenght
    ✓ should return a circuit with the provided option "lenght"

  algo:ibm:buildCircuits
    ✓ should return a group of circuits for the default options
    ✓ should return a group of circuits for "lenght" optionhigher than the supported by "backendQubits" (odd)
    ✓ should return a single circuits (keeping array format) for "lenght" option lower than the supported by "backendQubits"
    ✓ should return a single circuits (keeping array format) for "lenght" option lower than the supported by "backendQubits" (odd)


  9 passing (5s)
  3 failing

  1) algo:ibm:random
       should return a jobId:
     Error: GENERIC_ERROR
      at request (/Users/danielbevenius/work/machine-learning/qiskit-js/packages/qiskit-cloud/lib/request.js:45:13)
      at processTicksAndRejections (internal/process/task_queues.js:89:5)

  2) algo:ibm:result
       should return the result passing jobId:
     TypeError: The "jobId" parameter is mandatory (string)
      at Object.module.exports.result (index.js:75:11)
      at Context.t (test/functional.js:84:28)
      at processImmediate (internal/timers.js:439:21)

  3) algo:ibm:genBin
       should return a jobId:
     Error: GENERIC_ERROR
      at request (/Users/danielbevenius/work/machine-learning/qiskit-js/packages/qiskit-cloud/lib/request.js:45:13)
      at processTicksAndRejections (internal/process/task_queues.js:89:5)




lerna ERR! npm run test stderr:
npm ERR! code ELIFECYCLE
npm ERR! errno 3
npm ERR! @qiskit/algo-ibm@0.9.0 test: `mocha --recursive test --timeout 20000 --color`
npm ERR! Exit status 3
npm ERR!
npm ERR! Failed at the @qiskit/algo-ibm@0.9.0 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/danielbevenius/.npm/_logs/2019-09-08T15_03_31_146Z-debug.log

lerna ERR! npm run test exited 3 in '@qiskit/algo-ibm'
npm ERR! code ELIFECYCLE
npm ERR! errno 3
npm ERR! qiskit-js@ test-algo-ibm: `lerna run test --scope @qiskit/algo-ibm`
npm ERR! Exit status 3
npm ERR!
npm ERR! Failed at the qiskit-js@ test-algo-ibm script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```
</details>


